### PR TITLE
Make the top-level await support an opt-in

### DIFF
--- a/src/py/pyodide/__init__.py
+++ b/src/py/pyodide/__init__.py
@@ -12,7 +12,7 @@
 # importing from these.
 __version__ = "0.22.0"
 
-__all__ = ["__version__", "console", "code", "ffi", "http", "webloop"]
+__all__ = ["__version__", "console", "code", "ffi", "http"]
 
 from typing import Any
 
@@ -54,12 +54,6 @@ DEPRECATED_LIST = {
     "register_js_module": "ffi",
     "unregister_js_module": "ffi",
 }
-
-
-from .webloop import _initialize_event_loop
-
-_initialize_event_loop()
-del _initialize_event_loop
 
 
 def __dir__() -> list[str]:

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -90,6 +90,11 @@
             BANNER = "Welcome to the Pyodide terminal emulator 🐍\\n" + BANNER
             pyconsole = PyodideConsole(__main__.__dict__)
             import builtins
+
+            from pyodide.webloop import _initialize_event_loop
+            _initialize_event_loop()
+            del _initialize_event_loop
+
             async def await_fut(fut):
               res = await fut
               if res is not None:


### PR DESCRIPTION
The WebLoop is not initialized by default,
but has to be initialized by the user when needed.

This harmonizes the behavior of Pyodide interpreter with the behavior of standard CPython as far as asyncio is is concerned.

(Update: I transferred this PR from the fork that is scheduled for deletion. The original URL was https://github.com/ondrej-stanek-ozobot/pyodide/pull/1)